### PR TITLE
Web - Inverted "Before Unload" hook

### DIFF
--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -138,7 +138,7 @@ export const Editor: FunctionComponent<EditorProps> = (props: EditorProps) => {
   ]);
   useEffect(handleEditorEvents(editor, version, setVersion), [editor, version]);
   useBeforeUnload(() => {
-    if (editor.isClean(version)) {
+    if (!editor.isClean(version)) {
       return "Are you sure you want to leave? Your changes haven't been saved.";
     }
   });


### PR DESCRIPTION
- Fixes issue where Web would only prompt you before leaving
when the editor was clean, instead of the other way around.